### PR TITLE
Rename workflow file. Add static branch name. Build only Ruby 3.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: Ruby
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 permissions:
   contents: read
@@ -14,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
# Issue #10

## Summary
1. Rename Workflow file.
2. Use static branch name on triggers.
3. Build only Ruby 3.0.